### PR TITLE
m8: Disable BLE_VND_INCLUDED for now

### DIFF
--- a/bluetooth/bdroid_buildcfg.h
+++ b/bluetooth/bdroid_buildcfg.h
@@ -19,7 +19,6 @@
 
 #define BTM_DEF_LOCAL_NAME        "HTC One M8"
 
-#define BLE_VND_INCLUDED          TRUE
 #define BLUETOOTH_QTI_SW          TRUE
 #define BT_CLEAN_TURN_ON_DISABLED TRUE
 


### PR DESCRIPTION
If enabled, crashes the stack when bluetooth is turned on.

Change-Id: I478970f153f8d8d6af44de6e0b21e68b4cb33a37